### PR TITLE
Quick fix for updated plains meeting point textures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # MacOS silliness
 .DS_Store
+/.idea/

--- a/kaisyn/atlas/structure/piece/jigsaw/single/outpost/camps/savanna_plateau/base_plate.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/outpost/camps/savanna_plateau/base_plate.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well",
   "priority": 1
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/outpost/camps/sparse_jungle/base_plate.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/outpost/camps/sparse_jungle/base_plate.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well",
   "priority": 1
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/outpost/camps/wooded_badlands/base_plate.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/outpost/camps/wooded_badlands/base_plate.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well",
   "priority": 1
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/flower_forest_japanese/houses/flower_forest_park_1.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/flower_forest_japanese/houses/flower_forest_park_1.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/flower_forest_japanese/houses/flower_forest_park_2.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/flower_forest_japanese/houses/flower_forest_park_2.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/flower_forest_japanese/town_centers/flower_forest_meeting_point_1.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/flower_forest_japanese/town_centers/flower_forest_meeting_point_1.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/flower_forest_japanese/town_centers/flower_forest_meeting_point_2.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/flower_forest_japanese/town_centers/flower_forest_meeting_point_2.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/jungle_tribal/town_centers/jungle_meeting_point_1.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/jungle_tribal/town_centers/jungle_meeting_point_1.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/jungle_tribal/town_centers/jungle_meeting_point_2.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/jungle_tribal/town_centers/jungle_meeting_point_2.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/jungle_tribal/town_centers/jungle_meeting_point_3.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/jungle_tribal/town_centers/jungle_meeting_point_3.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/meadow_swiss/town_centers/meadow_meeting_point_1.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/meadow_swiss/town_centers/meadow_meeting_point_1.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/mushroom_fields_fantasy/town_centers/mushroom_meeting_point_1.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/mushroom_fields_fantasy/town_centers/mushroom_meeting_point_1.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/old_growth_taiga_polish/town_centers/old_growth_taiga_meeting_point_1.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/old_growth_taiga_polish/town_centers/old_growth_taiga_meeting_point_1.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/snowy_taiga_viking/town_centers/snowy_taiga_meeting_point_1.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/snowy_taiga_viking/town_centers/snowy_taiga_meeting_point_1.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }

--- a/kaisyn/atlas/structure/piece/jigsaw/single/village/swamp_boat/town_centers/swamp_b_meeting_point_1.json
+++ b/kaisyn/atlas/structure/piece/jigsaw/single/village/swamp_boat/town_centers/swamp_b_meeting_point_1.json
@@ -1,4 +1,4 @@
 {
-  "textures": "antique_atlas:structure/village/plains/meeting_point",
+  "textures": "antique_atlas:structure/village/plains/well_covered",
   "priority": 900
 }


### PR DESCRIPTION
With the new village textures, plains/meeting_point got renamed to plains/well, which makes versions of AA with the updated textures spit warnings at startup. 

I plan to go back and revise all of the Towns & Towers villages to take advantage of the new tiles at some point but this will take care of the immediate errors.